### PR TITLE
[RELEASE] v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ Section Order:
 ### Security
 -->
 
+## [2.4.0] - 2025-06-03
+
+### Changed
+
+- Translations updated
+
 ### Removed
 
 - Cache breaker for static files. Doesn't work as expected with `django-sri`.

--- a/aa_bulletin_board/__init__.py
+++ b/aa_bulletin_board/__init__.py
@@ -5,5 +5,5 @@ App init
 # AA Bulletin Board
 from aa_bulletin_board.constants import APP_TITLE
 
-__version__ = "2.3.5"
+__version__ = "2.4.0"
 __title__ = APP_TITLE

--- a/aa_bulletin_board/locale/django.pot
+++ b/aa_bulletin_board/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Bulletin Board 2.3.5\n"
+"Project-Id-Version: AA Bulletin Board 2.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-bulletin-board/issues\n"
-"POT-Creation-Date: 2025-05-05 20:14+0200\n"
+"POT-Creation-Date: 2025-06-03 09:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## [2.4.0] - 2025-06-03

### Changed

- Translations updated

### Removed

- Cache breaker for static files. Doesn't work as expected with `django-sri`.