### PR TITLE
[RELEASE] v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [3.0.0] - 2026-06-07
+
 > [!IMPORTANT]
 >
 > **This version needs Alliance Auth v5!**
@@ -1177,6 +1179,7 @@ python manage.py migrate
 [2.5.4]: https://github.com/ppfeufer/aa-bulletin-board/compare/v2.5.3...v2.5.4 "v2.5.4"
 [2.5.5]: https://github.com/ppfeufer/aa-bulletin-board/compare/v2.5.4...v2.5.5 "v2.5.5"
 [2.6.0]: https://github.com/ppfeufer/aa-bulletin-board/compare/v2.5.5...v2.6.0 "v2.6.0"
-[in development]: https://github.com/ppfeufer/aa-bulletin-board/compare/v2.6.0...HEAD "In Development"
+[3.0.0]: https://github.com/ppfeufer/aa-bulletin-board/compare/v2.6.0...v3.0.0 "v3.0.0"
+[in development]: https://github.com/ppfeufer/aa-bulletin-board/compare/v3.0.0...HEAD "In Development"
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/ "Keep a Changelog"
 [semantic versioning]: https://semver.org/spec/v2.0.0.html "Semantic Versioning"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Make sure you're in the virtual environment (venv) of your Alliance Auth
 installation Then install the latest release directly from PyPi.
 
 ```shell
-pip install aa-bulletin-board==2.6.0
+pip install aa-bulletin-board==3.0.0
 ```
 
 ### Step 2: Configure Alliance Auth<a name="step-2-configure-alliance-auth"></a>

--- a/aa_bulletin_board/__init__.py
+++ b/aa_bulletin_board/__init__.py
@@ -5,6 +5,6 @@ App init
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.6.0"
+__version__ = "3.0.0"
 __title__ = "Bulletin Board"
 __title_translated__ = _("Bulletin Board")

--- a/aa_bulletin_board/locale/django.pot
+++ b/aa_bulletin_board/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Bulletin Board 2.6.0\n"
+"Project-Id-Version: AA Bulletin Board 3.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-bulletin-board/issues\n"
-"POT-Creation-Date: 2026-06-02 09:27+0200\n"
+"POT-Creation-Date: 2026-06-07 11:08+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## [3.0.0] - 2026-06-07

> [!IMPORTANT]
> 
> **This version needs Alliance Auth v5!**
> 
> Please make sure to update your Alliance Auth instance **before** you install this
> version, otherwise an update to Alliance Auth will be pulled in unsupervised.

### Removed

- Support for Alliance Auth v4